### PR TITLE
improve: extension method generation from lambda expressions

### DIFF
--- a/src/McpToolkit.Server.SourceGenerator/McpToolMethodGenerator.Emit.cs
+++ b/src/McpToolkit.Server.SourceGenerator/McpToolMethodGenerator.Emit.cs
@@ -65,12 +65,11 @@ partial class McpToolMethodGenerator
             }
         }
 
-        foreach (var group in toolMethodGroup.GroupBy(x => x.DelegateType))
+        using (builder.BeginBlock($"public static partial void Add(this global::McpToolkit.Server.IMcpServerTools tools, string name, string? description, global::System.Delegate action)"))
         {
-            using var _1 = builder.BeginBlock($"public static void Add(this global::McpToolkit.Server.IMcpServerTools tools, string name, string? description, {group.Key} action)");
             using var _2 = builder.BeginBlock("switch (name)");
 
-            foreach (var (meta, delegateType) in group.Distinct())
+            foreach (var (meta, delegateType) in toolMethodGroup)
             {
                 builder.AppendLine($"case \"{meta.Name}\":");
                 using var _ = builder.BeginBlock();

--- a/src/McpToolkit.Server.SourceGenerator/McpToolMethodGenerator.cs
+++ b/src/McpToolkit.Server.SourceGenerator/McpToolMethodGenerator.cs
@@ -19,10 +19,7 @@ namespace McpToolkit.Server
 {
     internal static partial class GeneratedMcpServerToolsExtensions
     {
-        public static void Add(this global::McpToolkit.Server.IMcpServerTools tools, string name, string? description, global::System.Delegate action)
-        {
-            throw new global::System.NotSupportedException("The code is not generated correctly");
-        }
+        public static partial void Add(this global::McpToolkit.Server.IMcpServerTools tools, string name, string? description, global::System.Delegate action);
     }
 }
 """);

--- a/src/McpToolkit.Server.SourceGenerator/Parser.cs
+++ b/src/McpToolkit.Server.SourceGenerator/Parser.cs
@@ -91,7 +91,7 @@ internal static class Parser
         {
             Name = toolName,
             Description = toolDescription,
-            InvocationSymbol = "action",
+            InvocationSymbol = $"(({lambdaType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)})action)",
             ReturnType = new(lambdaReturnType!),
             ReturnTypeName = lambdaReturnType?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
             Parameters = new(parameters),


### PR DESCRIPTION
Change the branching to occur within a single extension method instead of an overload for each delegate type.